### PR TITLE
Merge Somalia and Somaliland

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -57,6 +57,16 @@ Promise.all([
 );
 
 function init(err, geoFetched, informFetched){
+  // merge Somalia and Somaliland tiles according to IFRC standards
+  selected = d3.set(["SOM","SOL"]);
+  somalia = topojson.mergeArcs(geoFetched, geoFetched.objects.world.geometries.filter(function(d) { return selected.has(d.properties.iso); }))
+  somalia.properties = {
+    "iso": "SOM",
+    "name": "Somalia"
+  }
+  geoFetched.objects.world.geometries = geoFetched.objects.world.geometries.filter(function(d) { return !selected.has(d.properties.iso); })
+  geoFetched.objects.world.geometries.push(somalia)
+
   // stash our data as globally accessible variables
   world = topojson.feature(geoFetched, geoFetched.objects.world).features;
   // attach our inform data to our geo data


### PR DESCRIPTION
I was asked to merge Somalia and Somaliland in the maps since IFRC sees them as one region. It feels like applying the filter twice is ineffecient but I don't know enough javascript to come up with a better way. Maybe .splice() would work but I couldn't find an easy way to determine the index of Somalia and Somaliland. If you have suggestions I would be happy to improve.